### PR TITLE
Rename github.com/goware/saml to github.com/pressly/saml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # saml
 
-[![Build Status](https://travis-ci.org/goware/saml.svg?branch=master)](https://travis-ci.org/goware/saml)
+[![Build Status](https://travis-ci.org/pressly/saml.svg?branch=master)](https://travis-ci.org/goware/saml)
 ![cover.run go](https://img.shields.io/badge/cover.run-33.4%25-red.svg?style=flat-square)
-[![Go Report Card](https://goreportcard.com/badge/github.com/goware/saml)](https://goreportcard.com/report/github.com/goware/saml)
-[![GoDoc](https://godoc.org/github.com/goware/saml?status.svg)](http://godoc.org/github.com/goware/saml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/pressly/saml)](https://goreportcard.com/report/github.com/goware/saml)
+[![GoDoc](https://godoc.org/github.com/pressly/saml?status.svg)](http://godoc.org/github.com/goware/saml)
 
 Package `saml` provides tools and middleware for implementing [SAML based single
 sign-on](https://auth0.com/blog/how-saml-authentication-works/).
@@ -12,7 +12,7 @@ Currently, the `saml` package depends on the
 [xmlsec1](https://www.aleksey.com/xmlsec/index.html) command.
 
 See
-[_example/servers](https://github.com/goware/saml/tree/master/_example/servers)
+[_example/servers](https://github.com/pressly/saml/tree/master/_example/servers)
 for example implementations of IdP and SP servers.
 
 ## SAML SSO basics

--- a/_example/servers/README.md
+++ b/_example/servers/README.md
@@ -41,13 +41,13 @@ only for testing.
 Once you have both keypairs install the `idp-server` tool:
 
 ```
-go install github.com/goware/saml/_example/servers/idp-server
+go install github.com/pressly/saml/_example/servers/idp-server
 ```
 
 and the `sp-server` tool:
 
 ```
-go install github.com/goware/saml/_example/servers/sp-server
+go install github.com/pressly/saml/_example/servers/sp-server
 ```
 
 ## Testing IdP-initiated SSO

--- a/_example/servers/idp-server/idp-server.go
+++ b/_example/servers/idp-server/idp-server.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/goware/saml"
+	"github.com/pressly/saml"
 	"github.com/pkg/errors"
 	"github.com/pressly/chi"
 

--- a/_example/servers/sp-server/sp-server.go
+++ b/_example/servers/sp-server/sp-server.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi"
-	"github.com/goware/saml"
+	"github.com/pressly/saml"
 	"github.com/pkg/errors"
 )
 

--- a/idp.go
+++ b/idp.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goware/saml/xmlsec"
+	"github.com/pressly/saml/xmlsec"
 	"github.com/pkg/errors"
 )
 

--- a/saml.go
+++ b/saml.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	"github.com/goware/saml/xmlsec"
+	"github.com/pressly/saml/xmlsec"
 	"github.com/pkg/errors"
 )
 

--- a/schema.go
+++ b/schema.go
@@ -28,7 +28,7 @@ import (
 	"encoding/xml"
 	"time"
 
-	"github.com/goware/saml/xmlsec"
+	"github.com/pressly/saml/xmlsec"
 )
 
 const (
@@ -73,7 +73,7 @@ type AuthnRequest struct {
 	ID string `xml:",attr"`
 
 	// The version of this request.
-	// Only version 2.0 is supported by goware/saml
+	// Only version 2.0 is supported by pressly/saml
 	Version string `xml:",attr"`
 
 	// The time instant of issue of the request. The time value is encoded in UTC
@@ -163,7 +163,7 @@ type Response struct {
 	ID string `xml:",attr"`
 
 	// The version of this request.
-	// Only version 2.0 is supported by goware/saml
+	// Only version 2.0 is supported by pressly/saml
 	Version string `xml:",attr"`
 
 	// The time instant of issue of the request. The time value is encoded in UTC

--- a/sp_handlers.go
+++ b/sp_handlers.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/beevik/etree"
-	"github.com/goware/saml/xmlsec"
+	"github.com/pressly/saml/xmlsec"
 	"github.com/pkg/errors"
 	dsig "github.com/russellhaering/goxmldsig"
 )


### PR DESCRIPTION
We renamed github.com/goware/saml to github.com/pressly/saml.

This is a breaking API change. But that's fine, since we haven't released v1.0 yet.